### PR TITLE
Fixed problem when updating Android Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ In order to use this in your project.
  
   Change the import statements in each of those files, to correspond with your package name.
 
-* Then place the folder from this projected into the following location in your Android Studio Installation:
+* Then place the folder from this project into your '.android/' of your system:
 ```
-/Applications/Android Studio.app/Contents/plugins/android/lib/templates/other/
+~/.android/templates/other/
 ```
+
 * Restart Android Studio, and then when you right click on a folder to create a new file, you will be able to see the new option to create a MVP Function.


### PR DESCRIPTION
The project folder should be placed in the folder '~/.android/templates/other/

The problem of when updating the Android Studio we would lose all our custom templates was fixed, check issue: https://issuetracker.google.com/issues/37105193

